### PR TITLE
Alarm: Support devices using timerfd without CLOCK_POWEROFF_ALARM

### DIFF
--- a/services/core/jni/com_android_server_AlarmManagerService.cpp
+++ b/services/core/jni/com_android_server_AlarmManagerService.cpp
@@ -424,6 +424,10 @@ static jlong init_timerfd()
 
     for (size_t i = 0; i < N_ANDROID_TIMERFDS; i++) {
         fds[i] = timerfd_create(android_alarm_to_clockid[i], 0);
+        if ((fds[i] < 0) && (android_alarm_to_clockid[i] == CLOCK_POWEROFF_ALARM)) {
+            ALOGV("timerfd does not support CLOCK_POWEROFF_ALARM, using CLOCK_REALTIME_ALARM instead");
+            fds[i] = timerfd_create(CLOCK_REALTIME_ALARM, 0);
+        }
         if (fds[i] < 0) {
             ALOGV("timerfd_create(%u) failed: %s",  android_alarm_to_clockid[i],
                     strerror(errno));


### PR DESCRIPTION
timerfd CLOCK_POWEROFF_ALARM is patch from qcom for power off alarm
support in qcom devices. Some old devices or non-qcom devices
does not support CLOCK_POWEROFF_ALARM in timerfd that results in
init_timerfd function fails.

Use fallback mechanism if devices does not support CLOCK_POWEROFF_ALARM
in timerfd use CLOCK_REALTIME instead.

Change-Id: I166f2a3cea21cd6dc67a520e268315076dc4356a